### PR TITLE
Remove duplicate crossline and crossline text rendering

### DIFF
--- a/lib/renderer/base_chart_painter.dart
+++ b/lib/renderer/base_chart_painter.dart
@@ -120,7 +120,6 @@ abstract class BaseChartPainter extends CustomPainter {
       drawNowPrice(canvas);
 
       if (isLongPress == true || (isTapShowInfoDialog && isOnTap)) {
-        drawCrossLine(canvas, size);
         drawCrossLineText(canvas, size);
       }
     }

--- a/lib/renderer/chart_painter.dart
+++ b/lib/renderer/chart_painter.dart
@@ -198,7 +198,6 @@ class ChartPainter extends BaseChartPainter {
     if ((isLongPress == true || (isTapShowInfoDialog && isOnTap)) &&
         isTrendLine == false) {
       drawCrossLine(canvas, size);
-      drawCrossLineText(canvas, size);
     }
     if (isTrendLine == true) drawTrendLines(canvas, size);
     canvas.restore();


### PR DESCRIPTION
When the graph is zoomed in or zoomed out and then a bar next from the beggining is selected, it can be noticed that the crossline and the text that pops up related to the selected bar are being renderend duplicated. This PR aims to solve this bug by removing the duplicate rendering.

Before: 

https://user-images.githubusercontent.com/38893955/154350371-8b74ab72-52ce-49a0-a092-b4f30920fdc9.mp4


After:

https://user-images.githubusercontent.com/38893955/154350576-2aad1150-1641-405d-a7d1-49312faec2fa.mp4


