### PR TITLE
Fix KChart and DephtChart onPress selection when they don't fill the whole screen

### DIFF
--- a/lib/depth_chart.dart
+++ b/lib/depth_chart.dart
@@ -32,12 +32,12 @@ class _DepthChartState extends State<DepthChart> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onLongPressStart: (details) {
-        pressOffset = details.globalPosition;
+        pressOffset = details.localPosition;
         isLongPress = true;
         setState(() {});
       },
       onLongPressMoveUpdate: (details) {
-        pressOffset = details.globalPosition;
+        pressOffset = details.localPosition;
         isLongPress = true;
         setState(() {});
       },

--- a/lib/k_chart_widget.dart
+++ b/lib/k_chart_widget.dart
@@ -178,9 +178,9 @@ class _KChartWidgetState extends State<KChartWidget>
             if (!widget.isTrendLine &&
                 _painter.isInMainRect(details.localPosition)) {
               isOnTap = true;
-              if (mSelectX != details.globalPosition.dx &&
+              if (mSelectX != details.localPosition.dx &&
                   widget.isTapShowInfoDialog) {
-                mSelectX = details.globalPosition.dx;
+                mSelectX = details.localPosition.dx;
                 notifyChanged();
               }
             }
@@ -234,37 +234,37 @@ class _KChartWidgetState extends State<KChartWidget>
           onLongPressStart: (details) {
             isOnTap = false;
             isLongPress = true;
-            if ((mSelectX != details.globalPosition.dx ||
+            if ((mSelectX != details.localPosition.dx ||
                     mSelectY != details.globalPosition.dy) &&
                 !widget.isTrendLine) {
-              mSelectX = details.globalPosition.dx;
+              mSelectX = details.localPosition.dx;
               notifyChanged();
             }
             //For TrendLine
             if (widget.isTrendLine && changeinXposition == null) {
-              mSelectX = changeinXposition = details.globalPosition.dx;
+              mSelectX = changeinXposition = details.localPosition.dx;
               mSelectY = changeinYposition = details.globalPosition.dy;
               notifyChanged();
             }
             //For TrendLine
             if (widget.isTrendLine && changeinXposition != null) {
-              changeinXposition = details.globalPosition.dx;
+              changeinXposition = details.localPosition.dx;
               changeinYposition = details.globalPosition.dy;
               notifyChanged();
             }
           },
           onLongPressMoveUpdate: (details) {
-            if ((mSelectX != details.globalPosition.dx ||
+            if ((mSelectX != details.localPosition.dx ||
                     mSelectY != details.globalPosition.dy) &&
                 !widget.isTrendLine) {
-              mSelectX = details.globalPosition.dx;
+              mSelectX = details.localPosition.dx;
               mSelectY = details.localPosition.dy;
               notifyChanged();
             }
             if (widget.isTrendLine) {
               mSelectX =
-                  mSelectX + (details.globalPosition.dx - changeinXposition!);
-              changeinXposition = details.globalPosition.dx;
+                  mSelectX + (details.localPosition.dx - changeinXposition!);
+              changeinXposition = details.localPosition.dx;
               mSelectY =
                   mSelectY + (details.globalPosition.dy - changeinYposition!);
               changeinYposition = details.globalPosition.dy;


### PR DESCRIPTION
The selection based on the user's touch don't work well when the KChart and DepthChart are placed in an app but don't fill the whole screen. The selection also doesn't work properlly when used with the ResponsiveFramework package because of the resizing that is applied to the widgets.

https://user-images.githubusercontent.com/38893955/194149944-1af37c5a-4782-44a8-8d2c-2609063e152a.mp4

This PR aims to solve this bug by making both widgets use the touch's local position instead of the global position.